### PR TITLE
feat(build): Add build-rootfs.sh to build for foreign arch

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -1,0 +1,56 @@
+# YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
+---
+name: build-rootfs
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+          - armhf
+          - i386
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          # Relate-to: https://github.com/actions/checkout/pull/2081#2025
+          ref: ${{ github.ref }}
+
+      - id: describe
+        name: Describe HEAD
+        run: >-
+          echo "describe=$(git describe --tags --always || echo 0)"
+          | tee $GITHUB_OUTPUT
+      - name: Setup and build
+        run: ARCH=${{ matrix.arch }} ${file}
+        env:
+          file: extra/build/build-rootfs.sh
+      - name: Upload artifacts
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          # yamllint disable-line rule:line-length
+          name: ${{ github.event.repository.name }}-${{ steps.describe.outputs.describe }}-${{ matrix.arch }}
+          path: build/dist/
+      - name: Upload Release Asset
+        id: upload-release-asset
+        env:
+          token-defined: ${{ secrets.GH_SL_ACCESS_TOKEN != '' }}
+        # yamllint disable-line rule:line-length
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
+        # yamllint disable-line rule:line-length
+        if: ${{ github.ref_type == 'tag'  && env.token-defined }}
+        with:
+          files: build/dist/*
+          # yamllint disable-line rule:line-length
+          token: ${{ secrets.GH_SL_ACCESS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,14 +83,3 @@ jobs:
             sonar-project.properties
             .scannerwork/report-task.txt
             ${{ env.SONAR_OUT_DIR }}
-
-      - name: Create GitHub Release
-        env:
-          token-defined: ${{ secrets.GITHUB_TOKEN != '' }}
-          REPO_NAME: ${GITHUB_REPOSITORY#*/}
-        uses: softprops/action-gh-release@v2
-        # yamllint disable rule:line-length
-        if: ${{ github.event_name == 'push' && contains( github.ref, 'refs/tags/' ) }}
-        with:
-          files: ./build/*.deb
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# .gitignore
+
 # Prerequisites
 *.d
 
@@ -54,3 +56,10 @@ dkms.conf
 # Exclude CMake build folder 
 build
 .vscode
+
+# More folders
+tmp/
+dist/
+
+# Editors
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,14 @@ install(FILES
 TYPE DOC
 )
 
-set(CPACK_GENERATOR "DEB")
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Silicon Labs")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libjson-c5 | libjson-c4 | libjson-c3 | libjson-c2")
+set(CPACK_PACKAGE_VENDOR "Silicon Labs")
+set(CPACK_PACKAGE_CONTACT "https://github.com/SiliconLabsSoftware/z-wave-nvm-migration-tool")
+if(NOT CPACK_GENERATOR)
+  set(CPACK_GENERATOR "DEB")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libjson-c5 | libjson-c4 | libjson-c3 | libjson-c2")
+  set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+endif()
+
+message(${CPACK_PACKAGE_FILE_NAME} "")
 
 include(CPack)

--- a/extra/build/build-rootfs.sh
+++ b/extra/build/build-rootfs.sh
@@ -1,0 +1,164 @@
+#! /usr/bin/env bash
+# -*- mode: Bash; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
+# vim:shiftwidth=4:softtabstop=4:tabstop=4:
+# SPDX-License-Identifier: Zlib
+# SPDX-License-URL: https://spdx.org/licenses/Zlib
+# SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+
+set -e
+set -x
+
+cat<<EOF
+Usage:
+
+ARCH=arm64 ./scripts/build-rootfs.sh
+EOF
+
+project="z-wave-nvm-migration-tool"
+debian_suite="${debian_suite:=bookworm}"
+debian_arch=$(dpkg --print-architecture)
+
+# Can be overloaded from env eg: ARCH=arm64"
+target_debian_arch=${ARCH:="${debian_arch}"}
+
+debian_mirror_url="http://deb.debian.org/debian"
+sudo="sudo"
+machine="${project}-${debian_suite}-${target_debian_arch}-rootfs"
+rootfs_dir="/var/tmp/var/lib/machines/${machine}"
+MAKE="/usr/bin/make"
+CURDIR="$PWD"
+chroot="systemd-nspawn"
+packages="debootstrap \
+  debian-archive-keyring \
+  systemd-container \
+  time \
+"
+
+# Guess values to be adjusted
+CMAKE_SYSTEM_PROCESSOR="$ARCH"
+qemu_arch="${ARCH}"
+qemu_system="qemu-system-${qemu_arch}"
+qemu_package="${qemu_system}"       
+
+case $target_debian_arch in
+    amd64)
+        qemu_system="qemu-system-${CMAKE_SYSTEM_PROCESSOR}"
+        export CMAKE_SYSTEM_PROCESSOR="x86_64"
+        qemu_package="qemu-system-x86"
+        ;;
+
+    arm64)
+        qemu_arch="aarch64"
+        qemu_system="qemu-system-${qemu_arch}"
+        export CMAKE_SYSTEM_PROCESSOR="${qemu_arch}"
+        qemu_package="qemu-system-arm"
+        ;;
+
+    armhf)
+        debian_arch="armhf"
+        qemu_arch="arm"
+        qemu_system="qemu-system-${qemu_arch}"
+        export CMAKE_SYSTEM_PROCESSOR="armv7l"
+        qemu_package="qemu-system-arm"
+
+        # Workaround: https://github.com/armbian/build/issues/5330
+        binfmt_file="/var/lib/binfmts/qemu-${qemu_arch}"
+        [ -e "$binfmt_file" ] || cat<<EOF \
+                | { sudo mkdir -p /var/lib/binfmts && sudo tee "$binfmt_file" ; }
+package qemu-user-static
+interpreter /usr/libexec/qemu-binfmt/arm-binfmt-P
+magic \x7f\x45\x4c\x46\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00
+offset 0
+mask \xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff
+credentials yes
+fix_binary no
+preserve yes
+EOF
+        ;;
+    i386)
+        MAKE="linux32 ${MAKE}"
+        ;;
+    *)
+        echo "warning: Not supported yet"
+        ;;
+esac
+qemu_file="/usr/bin/${qemu_system}"
+binfmt_file="/var/lib/binfmts/qemu-${qemu_arch}"
+
+${sudo} apt-get update
+${sudo} apt install -y ${packages}
+
+if [ "${debian_target_arch}" != "${debian_arch}" ] ; then
+    echo "log: ${ARCH}: Support foreign arch: ${qemu_arch}"
+    ${sudo} apt-get update
+    packages="binfmt-support qemu-user-static ${qemu_package}"
+    ${sudo} apt install -y ${packages}
+
+    if [ -e "${qemu_file}" ]; then
+        ${sudo} update-binfmts --enable "qemu-${qemu_arch}" \
+            || find /usr/libexec/qemu-binfmt/
+    fi
+fi
+
+if [ ! -d "${rootfs_dir}" ] ; then
+    ${sudo} mkdir -pv "${rootfs_dir}"
+    time ${sudo} debootstrap \
+         --arch="${target_debian_arch}" \
+	       "${debian_suite}" "${rootfs_dir}" "${debian_mirror_url}"
+    ${sudo} chmod -v u+rX "${rootfs_dir}"
+fi
+
+### Environement to pass
+
+env_vars_options=""
+for i in $env_vars; do
+    env_vars_options="$env_vars_options --setenv=$i"
+done
+
+### Workarounds/Optimizations
+
+case ${chroot} in
+    "systemd-nspawn")
+        rootfs_shell="${sudo} systemd-nspawn \
+ --directory="${rootfs_dir}" \
+ --machine="${machine}" \
+ --bind="${CURDIR}:${CURDIR}" \
+ $env_vars_options
+"
+        if [ -e "${qemu_file}" ] ; then
+            rootfs_shell="$rootfs_shell --bind ${qemu_file}"
+        fi
+        ;;
+    *)
+        rootfs_shell="${sudo} chroot ${rootfs_dir}"
+        l="dev dev/pts sys proc"
+        for t in $l ; do
+            $sudo mkdir -p "${rootfs_dir}/$t"
+            $sudo mount --bind "/$t" "${rootfs_dir}/$t"
+        done
+    ;;
+esac
+
+${rootfs_shell} \
+    apt-get install -y -- make sudo util-linux git
+
+# echo "log: To prevent 'fatal: detected dubious ownership in repository'"
+${rootfs_shell} \
+    git config --global --add safe.directory "${CURDIR}"
+
+args="help setup default"
+[ "$1" = "" ] || args="$@"
+
+${rootfs_shell}	\
+    ${MAKE} \
+    --directory="${CURDIR}" \
+    --file="${CURDIR}/helper.mk" \
+    USER="${USER}" \
+    ${env_vars} \
+    -- \
+    ${args} \
+    target_debian_arch="${target_debian_arch}" \
+    CMAKE_SYSTEM_PROCESSOR="${CMAKE_SYSTEM_PROCESSOR}" \
+    # EoL
+
+echo "sudo du -hs -- '/var/tmp/var/lib/machines/${machine}' # can be removed now"

--- a/helper.mk
+++ b/helper.mk
@@ -218,8 +218,8 @@ dist/cmake: ${build_dir}
 
 dist/deb: ${build_dir}
 	${cmake} --build $< --target package
-	install -d ${@D}
-	cp -av ${<}/*.deb ${@D}/
+	mkdir -p ${<}/${@D}
+	cp -av ${<}/*.deb ${<}/${@D}/
 
 dist: dist/deb
 

--- a/helper.mk
+++ b/helper.mk
@@ -236,3 +236,8 @@ all/default: ${default_rules}
 run:
 	file -E ${run_file}
 	${run_file} ${run_args}
+
+arch/%: extra/build/build-rootfs.sh
+	ARCH=${@F} $<
+
+arch/all: arch/armhf arch/arm64 arch/amd64 arch/i366 


### PR DESCRIPTION
This script can be used to build and run package without CI

Output will be:

./build/*-*${arch}.deb

It has been tested on debian-12.

This change has been adapted from version I made in other projects (see related link).

Also, I have adjusted the licence to comply current OSS policy, as it is not embedded code, it can be relaxed from MSLA to ZLIB.

Relate-to: https://github.com/SiliconLabs/zipgateway/pull/4
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/5