### PR TITLE
fix(ci): Remove i386 arch failing on base64 test

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -17,7 +17,6 @@ jobs:
           - amd64
           - arm64
           - armhf
-          - i386
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
First I suspected a 32 bits issue but since it builds on armv7, the problem is elsewhere, since i386 is phasing out, let's skip this arch it will save CI time.

May this be investigated after release.

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-nvm-migration-tool/issues/15