### PR TITLE
Filter forbidden migrations

### DIFF
--- a/tests/controllerlib/test_controller_nvm.c
+++ b/tests/controllerlib/test_controller_nvm.c
@@ -19,7 +19,7 @@ int mock_int_array[10] = {};
 uint8_t mock_byte_array[10] = {};
 
 /* Mocked functions */
-/* json get functions */
+// Callback function for mocking json_get_intarray in unit tests.
 uint8_t json_get_intarray_Callback(json_object *parent, const char *key, int *array, uint32_t length, bool is_required, int cmock_num_calls)
 {
   for (uint32_t i = 0; i < length; i++)
@@ -29,6 +29,7 @@ uint8_t json_get_intarray_Callback(json_object *parent, const char *key, int *ar
   return length;
 }
 
+// Callback function for mocking json_get_bytearray in unit tests.
 uint8_t json_get_bytearray_Callback(json_object *parent, const char *key, uint8_t *array, uint32_t length, bool is_required, int cmock_num_calls)
 {
   for (uint32_t i = 0; i < length; i++)
@@ -38,6 +39,22 @@ uint8_t json_get_bytearray_Callback(json_object *parent, const char *key, uint8_
   return length;
 }
 
+json_object *json_return_object = NULL;
+// Callback function for mocking json_get_object_error_check in unit tests.
+// It sets *jo_val to json_return_object if available
+bool json_get_object_error_check_Callback(json_object *parent, const char *key, json_object **jo_val, json_type expected_type, bool is_required, int cmock_num_calls)
+{
+  if (json_return_object == NULL)
+  {
+    *jo_val = NULL;
+    return false;
+  }
+  else
+  {
+    *jo_val = json_return_object;
+    return true;
+  }
+}
 void setUp(void)
 {
 }
@@ -546,6 +563,104 @@ void test_parse_app_config_from_7_21(void)
   json_object_put(jo);
 }
 
+void test_json_get_nvm_layout(void)
+{
+  json_object *jo = json_tokener_parse("{"
+      "\"format\":4,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+      "}"
+  "}"); 
+  nvmLayout_t nvm_layout = NVM3_700s;
+  // controller object doesn't exist
+  json_return_object = NULL;
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  TEST_ASSERT_FALSE(json_get_nvm_layout("EFR32XG23", NULL, &nvm_layout));
+  // protocol version is NULL
+  json_return_object = json_tokener_parse("{"
+      "\"format\":4,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+          "\"applicationVersion\":\"7.18.0\""
+      "}"
+  "}"); 
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  json_get_string_ExpectAnyArgsAndReturn(NULL);
+  json_get_string_ExpectAndReturn(json_return_object, "applicationVersion", "", JSON_REQUIRED, "7.19.0");
+  json_get_int_ExpectAndReturn(jo, "applicationFileFormat", 0, JSON_REQUIRED, 0);
+  TEST_ASSERT_FALSE(json_get_nvm_layout("EFR32XG23", jo, &nvm_layout));
+  // app version is NULL
+  json_return_object = json_tokener_parse("{"
+      "\"format\":4,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+          "\"protocolVersion\":\"7.18.0\","
+      "}"
+  "}");
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  json_get_string_ExpectAndReturn(json_return_object, "protocolVersion", "", JSON_REQUIRED, "7.18.0");
+  json_get_string_ExpectAnyArgsAndReturn(NULL);
+  json_get_int_ExpectAndReturn(jo, "applicationFileFormat", 0, JSON_REQUIRED, 0);
+  TEST_ASSERT_FALSE(json_get_nvm_layout("EFR32XG23", jo, &nvm_layout));
+  // 800 Series
+  json_return_object = json_tokener_parse("{"
+      "\"format\":5,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+          "\"protocolVersion\":\"7.19.0\","
+          "\"applicationVersion\":\"7.19.0\""
+      "}"
+  "}");
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  json_get_string_ExpectAndReturn(json_return_object, "protocolVersion", "", JSON_REQUIRED, "7.19.0");
+  json_get_string_ExpectAndReturn(json_return_object, "applicationVersion", "", JSON_REQUIRED, "7.19.0");
+  json_get_int_ExpectAndReturn(jo, "applicationFileFormat", 0, JSON_REQUIRED, 0);
+  TEST_ASSERT_TRUE(json_get_nvm_layout("EFR32XG23", jo, &nvm_layout));
+  TEST_ASSERT_EQUAL(NVM3_800s_FROM_719, nvm_layout);
+  json_return_object = json_tokener_parse("{"
+      "\"format\":4,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+          "\"protocolVersion\":\"7.18.0\","
+          "\"applicationVersion\":\"7.18.0\""
+      "}"
+  "}");
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  json_get_string_ExpectAndReturn(json_return_object, "protocolVersion", "", JSON_REQUIRED, "7.18.0");
+  json_get_string_ExpectAndReturn(json_return_object, "applicationVersion", "", JSON_REQUIRED, "7.18.0");
+  json_get_int_ExpectAndReturn(jo, "applicationFileFormat", 0, JSON_REQUIRED, 0);
+  TEST_ASSERT_TRUE(json_get_nvm_layout("EFR32XG23", jo, &nvm_layout));
+  TEST_ASSERT_EQUAL(NVM3_800s_PRIOR_719, nvm_layout);
+  // 700 Series 
+  json_return_object = json_tokener_parse("{"
+      "\"format\":4,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+          "\"protocolVersion\":\"7.18.0\","
+          "\"applicationVersion\":\"7.18.0\""
+      "}"
+  "}");
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  json_get_string_ExpectAndReturn(json_return_object, "protocolVersion", "", JSON_REQUIRED, "7.18.0");
+  json_get_string_ExpectAndReturn(json_return_object, "applicationVersion", "", JSON_REQUIRED, "7.18.0");
+  json_get_int_ExpectAndReturn(jo, "applicationFileFormat", 0, JSON_REQUIRED, 0);
+  TEST_ASSERT_TRUE(json_get_nvm_layout("EFR32XG13", jo, &nvm_layout));
+  TEST_ASSERT_EQUAL(NVM3_700s, nvm_layout);
+  // 700s only supports up to 7.21.x
+  jo = json_tokener_parse("{"
+      "\"format\":5,"
+      "\"applicationFileFormat\":0,"
+      "\"controller\":{"
+          "\"protocolVersion\":\"7.22.0\","
+          "\"applicationVersion\":\"7.22.0\""
+      "}");
+  json_get_object_error_check_StubWithCallback(json_get_object_error_check_Callback);
+  json_get_string_ExpectAndReturn(json_return_object, "protocolVersion", "", JSON_REQUIRED, "7.22.0");
+  json_get_string_ExpectAndReturn(json_return_object, "applicationVersion", "", JSON_REQUIRED, "7.22.0");
+  json_get_int_ExpectAndReturn(jo, "applicationFileFormat", 0, JSON_REQUIRED, 0);
+  TEST_ASSERT_FALSE(json_get_nvm_layout("EFR32XG13", jo, &nvm_layout));
+}
+
 void test_file_version(void)
 {
   TEST_ASSERT_EQUAL_HEX(0x01070B00, file_version(1, 7, 11, 0));
@@ -582,5 +697,6 @@ int main(void)
   RUN_TEST(test_parse_node_security);
   RUN_TEST(test_parse_route_cache_line_json);
   RUN_TEST(test_file_version);
+  RUN_TEST(test_json_get_nvm_layout);
   return UNITY_END();
 }

--- a/zw_nvm_converter/controllerlib_7.xx/api_wrappers.c
+++ b/zw_nvm_converter/controllerlib_7.xx/api_wrappers.c
@@ -52,9 +52,8 @@ static size_t nvmlib_json_to_nvm_common(json_object *jo, uint8_t **nvm_buf_ptr, 
 {
   size_t bin_size = 0;
   uint8_t *buf_ptr = 0;
-  nvmLayout_t nvm_layout = json_get_nvm_layout(device_info, jo);
-  /* TODO Implement this */
-  if (true)
+  nvmLayout_t nvm_layout = NVM3_700s; 
+  if (json_get_nvm_layout(device_info, jo, &nvm_layout))
   {
     open_controller_nvm(NULL, 0, nvm_layout);
 

--- a/zw_nvm_converter/controllerlib_7.xx/controller_nvm.c
+++ b/zw_nvm_converter/controllerlib_7.xx/controller_nvm.c
@@ -2757,12 +2757,6 @@ bool json_get_nvm_layout(const char *device_info, json_object *jo, nvmLayout_t *
     return false;
   }
 
-  if (false == set_target_version(protocol_version, app_version))
-  {
-    printf("json_get_nvm_layout:set_target_version() error\n");
-    return false;
-  }
-
   if (strcmp(device_info, "EFR32XG28") == 0 || strcmp(device_info, "EFR32XG23") == 0)
   {
     if (strncmp(protocol_version, "7.19", 4) >= 0)
@@ -2788,6 +2782,12 @@ bool json_get_nvm_layout(const char *device_info, json_object *jo, nvmLayout_t *
       printf("700 Series only supports protocol versions up to 7.21.x\n");
       return false;
     }
+  }
+
+  if (false == set_target_version(protocol_version, app_version))
+  {
+    printf("json_get_nvm_layout:set_target_version() error\n");
+    return false;
   }
 
   return true;

--- a/zw_nvm_converter/controllerlib_7.xx/controller_nvm.c
+++ b/zw_nvm_converter/controllerlib_7.xx/controller_nvm.c
@@ -2730,17 +2730,16 @@ static bool parse_controller_nvm719_json(json_object *jo_ctrl, nvmLayout_t nvm_l
 }
 
 /*****************************************************************************/
-nvmLayout_t json_get_nvm_layout(const char *device_info, json_object *jo)
+bool json_get_nvm_layout(const char *device_info, json_object *jo, nvmLayout_t *nvm_layout)
 {
   json_object *jo_ref = NULL;
   const char *protocol_version;
   const char *app_version;
-  nvmLayout_t nvm_layout = NVM3_700s;
 
   if (false == json_get_object_error_check(jo, "controller", &jo_ref, json_type_object, JSON_REQUIRED))
   {
     printf("json_get_nvm_layout: json_get_object_error_check() error: controller\n");
-    return nvm_layout;
+    return false;
   }
 
   protocol_version = json_get_string(jo_ref, "protocolVersion", "", JSON_REQUIRED);
@@ -2750,12 +2749,12 @@ nvmLayout_t json_get_nvm_layout(const char *device_info, json_object *jo)
   if (protocol_version == NULL)
   {
     printf("json_get_nvm_layout: Failed to retrieve protocolVersion\n");
-    return nvm_layout;
+    return false;
   }
   if (app_version == NULL)
   {
     printf("json_get_nvm_layout: Failed to retrieve appVersion\n");
-    return nvm_layout;
+    return false;
   }
 
   if (false == set_target_version(protocol_version, app_version))
@@ -2768,22 +2767,30 @@ nvmLayout_t json_get_nvm_layout(const char *device_info, json_object *jo)
   {
     if (strncmp(protocol_version, "7.19", 4) >= 0)
     {
-      nvm_layout = NVM3_800s_FROM_719;
+      *nvm_layout = NVM3_800s_FROM_719;
       hardware_info = (strcmp(device_info, "EFR32XG28") == 0) ? EFR32XG28 : EFR32XG23;
     }
     else
     {
-      nvm_layout = NVM3_800s_PRIOR_719;
+      *nvm_layout = NVM3_800s_PRIOR_719;
       hardware_info = (strcmp(device_info, "EFR32XG28") == 0) ? EFR32XG28 : EFR32XG23;
     }
   }
   else if (strcmp(device_info, "EFR32XG14") == 0 || strcmp(device_info, "EFR32XG13") == 0)
   {
-    nvm_layout = NVM3_700s;
-    hardware_info = ZW_700s;
+    if (strncmp(protocol_version, "7.21", 4) <= 0)
+    {
+      *nvm_layout = NVM3_700s;
+      hardware_info = ZW_700s;
+    }
+    else 
+    {
+      printf("700 Series only supports protocol versions up to 7.21.x\n");
+      return false;
+    }
   }
 
-  return nvm_layout;
+  return true;
 }
 
 /*****************************************************************************/

--- a/zw_nvm_converter/controllerlib_7.xx/controller_nvm.h
+++ b/zw_nvm_converter/controllerlib_7.xx/controller_nvm.h
@@ -37,6 +37,6 @@ json_object* protocol_nvm_get_json(void);
 json_object* app_nvm_get_json(void);
 
 nvmLayout_t read_layout_from_nvm_size(size_t nvm_size);
-nvmLayout_t json_get_nvm_layout(const char *device_info, json_object *jo);
+bool json_get_nvm_layout(const char *device_info, json_object *jo, nvmLayout_t *nvm_layout);
 
 #endif // _NVMLIB711_H


### PR DESCRIPTION
* Added checks to prevent generating NVM3 for 700 Series with version > 7.21.x
* Added test for function json_get_nvm_layout(), with case that checks for above rule.
Related-to: [issue #22](https://github.com/SiliconLabsSoftware/z-wave-nvm-migration-tool/issues/22)