### PR TITLE
fix(ci): Enable runner overload using project variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       statuses: write
     env:
       project-name: z-wave-protocol-controller  # Align to docker (lowercase)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER || 'ubuntu-24.04' }}
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - id: download


### PR DESCRIPTION
This will prevent "out of plan" errors like:

"The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings"