### PR TITLE
fix(legal): Relicence files form MIT to ZLib to comply policy

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,5 +1,6 @@
 # YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Zlib
+# SPDX-License-URL: https://spdx.org/licenses/Zlib.txt
 # SPDX-FileCopyrightText: 2025 Silicon Laboratories Inc. https://www.silabs.com
 ---
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 # YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Zlib
+# SPDX-License-URL: https://spdx.org/licenses/Zlib.txt
 # SPDX-FileCopyrightText: 2025 Silicon Laboratories Inc. https://www.silabs.com
 ---
 name: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 # YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Zlib
+# SPDX-License-URL: https://spdx.org/licenses/Zlib.txt
 # SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 #!/bin/echo docker build . -f
 # -*- coding: utf-8 -*-
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Zlib
+# SPDX-License-URL: https://spdx.org/licenses/Zlib.txt
 # SPDX-FileCopyrightText: 2025 Silicon Laboratories Inc. https://www.silabs.com
 
 ARG OS_NAME=debian


### PR DESCRIPTION
Since those build files are not related to embedded code, they do not need to be covered by MSLA.
SL internal policy suggest to use Zlib, so let's align to this